### PR TITLE
#158 Previews hides when checkbox "Previews always on top" is unchecked

### DIFF
--- a/Eve-O-Preview/View/Implementation/ThumbnailView.cs
+++ b/Eve-O-Preview/View/Implementation/ThumbnailView.cs
@@ -216,7 +216,6 @@ namespace EveOPreview.View
 				return;
 			}
 
-			this.TopLevel = enableTopmost;
 			this.TopMost = enableTopmost;
 			this._overlay.TopMost = enableTopmost;
 


### PR DESCRIPTION
Form::TopMost and Form::TopLevel have different meaning. Pls read MSDN (remark section): https://docs.microsoft.com/en-us/dotnet/api/system.windows.forms.form.toplevel?view=netcore-3.1
