### PR TITLE
153: [Fix] Lock thumbnail size change during init

### DIFF
--- a/Eve-O-Preview/Presenters/Implementation/MainFormPresenter.cs
+++ b/Eve-O-Preview/Presenters/Implementation/MainFormPresenter.cs
@@ -89,10 +89,9 @@ namespace EveOPreview.Presenters
 
 		private async void UpdateThumbnailsSize()
 		{
-			this.SaveApplicationSettings();
-
 			if (!this._suppressSizeNotifications)
 			{
+				this.SaveApplicationSettings();
 				await this._mediator.Publish(new ThumbnailConfiguredSizeUpdated());
 			}
 		}

--- a/Eve-O-Preview/Presenters/Implementation/MainFormPresenter.cs
+++ b/Eve-O-Preview/Presenters/Implementation/MainFormPresenter.cs
@@ -49,6 +49,7 @@ namespace EveOPreview.Presenters
 
 		private void Activate()
 		{
+			this._suppressSizeNotifications = true;
 			this.LoadApplicationSettings();
 			this.View.SetDocumentationUrl(MainFormPresenter.FORUM_URL);
 			this.View.SetVersionInfo(this.GetApplicationVersion());
@@ -58,6 +59,7 @@ namespace EveOPreview.Presenters
 			}
 
 			this._mediator.Send(new StartService());
+			this._suppressSizeNotifications = false;
 		}
 
 		private void Minimize()


### PR DESCRIPTION
This PR fixes #153 

The root cause is from https://github.com/Phrynohyas/eve-o-preview/blob/bc06d9ae9cc5802b9dff0b8d08b755bcd5b12221/Eve-O-Preview/View/Implementation/MainForm.cs#L188

It prematurely turns off the suppression of the event as the handler may not be finished at that time.
