### PR TITLE
Allow storing thumbnails location where both X and Y are negative

### DIFF
--- a/Eve-O-Preview/View/Implementation/ThumbnailView.cs
+++ b/Eve-O-Preview/View/Implementation/ThumbnailView.cs
@@ -91,7 +91,7 @@ namespace EveOPreview.View
 			get => this.Location;
 			set
 			{
-				if ((value.X > 0) || (value.Y > 0))
+				if ((value.X != 0) || (value.Y != 0))
 				{
 					this.StartPosition = FormStartPosition.Manual;
 				}


### PR DESCRIPTION
My secondary monitor is on the top left of my main monitor and the thumbnails I put there has both negative X and Y and the position will not be stored. This one liner fixes it for me.