### PR TITLE
Use shortcut to activate/cycle next EVE window.

### DIFF
--- a/Eve-O-Preview/Configuration/Implementation/ThumbnailConfiguration.cs
+++ b/Eve-O-Preview/Configuration/Implementation/ThumbnailConfiguration.cs
@@ -51,8 +51,10 @@ namespace EveOPreview.Configuration.Implementation
 			this.EnableActiveClientHighlight = false;
 			this.ActiveClientHighlightColor = Color.GreenYellow;
 			this.ActiveClientHighlightThickness = 3;
-		}
 
+			this.NextWindowShortcut = "Ctrl + Tab";
+		}
+		public string NextWindowShortcut { get; set; }
 		public bool MinimizeToTray { get; set; }
 		public int ThumbnailRefreshPeriod { get; set; }
 

--- a/Eve-O-Preview/Configuration/Implementation/ThumbnailConfiguration.cs
+++ b/Eve-O-Preview/Configuration/Implementation/ThumbnailConfiguration.cs
@@ -53,8 +53,10 @@ namespace EveOPreview.Configuration.Implementation
 			this.ActiveClientHighlightThickness = 3;
 
 			this.NextWindowShortcut = "Ctrl + Tab";
+			this.NextWindowIgnoredTitles = new List<string>();
 		}
 		public string NextWindowShortcut { get; set; }
+		public IList<string> NextWindowIgnoredTitles { get; set; }
 		public bool MinimizeToTray { get; set; }
 		public int ThumbnailRefreshPeriod { get; set; }
 

--- a/Eve-O-Preview/Configuration/Implementation/ThumbnailConfiguration.cs
+++ b/Eve-O-Preview/Configuration/Implementation/ThumbnailConfiguration.cs
@@ -58,8 +58,8 @@ namespace EveOPreview.Configuration.Implementation
 		}
 		public string NextWindowShortcut { get; set; }
 		public string NextAnyWindowShortcut { get; set; }
-
 		public IList<string> NextWindowIgnoredTitles { get; set; }
+
 		public bool MinimizeToTray { get; set; }
 		public int ThumbnailRefreshPeriod { get; set; }
 

--- a/Eve-O-Preview/Configuration/Implementation/ThumbnailConfiguration.cs
+++ b/Eve-O-Preview/Configuration/Implementation/ThumbnailConfiguration.cs
@@ -55,10 +55,12 @@ namespace EveOPreview.Configuration.Implementation
 			this.NextWindowShortcut = "Ctrl + Tab";
 			this.NextAnyWindowShortcut = "Ctrl + Shift + Tab";
 			this.NextWindowIgnoredTitles = new List<string>();
+			this.NextWindowOrdering = new List<string>();
 		}
 		public string NextWindowShortcut { get; set; }
 		public string NextAnyWindowShortcut { get; set; }
 		public IList<string> NextWindowIgnoredTitles { get; set; }
+		public IList<string> NextWindowOrdering { get; set; }
 
 		public bool MinimizeToTray { get; set; }
 		public int ThumbnailRefreshPeriod { get; set; }

--- a/Eve-O-Preview/Configuration/Implementation/ThumbnailConfiguration.cs
+++ b/Eve-O-Preview/Configuration/Implementation/ThumbnailConfiguration.cs
@@ -53,9 +53,12 @@ namespace EveOPreview.Configuration.Implementation
 			this.ActiveClientHighlightThickness = 3;
 
 			this.NextWindowShortcut = "Ctrl + Tab";
+			this.NextAnyWindowShortcut = "Ctrl + Shift + Tab";
 			this.NextWindowIgnoredTitles = new List<string>();
 		}
 		public string NextWindowShortcut { get; set; }
+		public string NextAnyWindowShortcut { get; set; }
+
 		public IList<string> NextWindowIgnoredTitles { get; set; }
 		public bool MinimizeToTray { get; set; }
 		public int ThumbnailRefreshPeriod { get; set; }

--- a/Eve-O-Preview/Configuration/Interface/IThumbnailConfiguration.cs
+++ b/Eve-O-Preview/Configuration/Interface/IThumbnailConfiguration.cs
@@ -1,4 +1,5 @@
-﻿using System.Drawing;
+﻿using System.Collections.Generic;
+using System.Drawing;
 using System.Windows.Forms;
 
 namespace EveOPreview.Configuration
@@ -10,6 +11,7 @@ namespace EveOPreview.Configuration
 
 		bool EnableCompatibilityMode { get; set; }
 		string NextWindowShortcut { get; set; }
+		IList<string> NextWindowIgnoredTitles { get; set; }
 
 		double ThumbnailOpacity { get; set; }
 

--- a/Eve-O-Preview/Configuration/Interface/IThumbnailConfiguration.cs
+++ b/Eve-O-Preview/Configuration/Interface/IThumbnailConfiguration.cs
@@ -14,6 +14,7 @@ namespace EveOPreview.Configuration
 		string NextWindowShortcut { get; set; }
 		string NextAnyWindowShortcut { get; set; }
 		IList<string> NextWindowIgnoredTitles { get; set; }
+		IList<string> NextWindowOrdering { get; set; }
 
 		double ThumbnailOpacity { get; set; }
 

--- a/Eve-O-Preview/Configuration/Interface/IThumbnailConfiguration.cs
+++ b/Eve-O-Preview/Configuration/Interface/IThumbnailConfiguration.cs
@@ -10,6 +10,7 @@ namespace EveOPreview.Configuration
 		int ThumbnailRefreshPeriod { get; set; }
 
 		bool EnableCompatibilityMode { get; set; }
+
 		string NextWindowShortcut { get; set; }
 		string NextAnyWindowShortcut { get; set; }
 		IList<string> NextWindowIgnoredTitles { get; set; }

--- a/Eve-O-Preview/Configuration/Interface/IThumbnailConfiguration.cs
+++ b/Eve-O-Preview/Configuration/Interface/IThumbnailConfiguration.cs
@@ -9,6 +9,7 @@ namespace EveOPreview.Configuration
 		int ThumbnailRefreshPeriod { get; set; }
 
 		bool EnableCompatibilityMode { get; set; }
+		string NextWindowShortcut { get; set; }
 
 		double ThumbnailOpacity { get; set; }
 

--- a/Eve-O-Preview/Configuration/Interface/IThumbnailConfiguration.cs
+++ b/Eve-O-Preview/Configuration/Interface/IThumbnailConfiguration.cs
@@ -11,6 +11,7 @@ namespace EveOPreview.Configuration
 
 		bool EnableCompatibilityMode { get; set; }
 		string NextWindowShortcut { get; set; }
+		string NextAnyWindowShortcut { get; set; }
 		IList<string> NextWindowIgnoredTitles { get; set; }
 
 		double ThumbnailOpacity { get; set; }

--- a/Eve-O-Preview/Eve-O-Preview.csproj
+++ b/Eve-O-Preview/Eve-O-Preview.csproj
@@ -89,6 +89,7 @@
     <Reference Include="Newtonsoft.Json, Version=12.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\packages\Newtonsoft.Json.12.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
+    <Reference Include="PresentationCore" />
     <Reference Include="System" />
     <Reference Include="System.Deployment" />
     <Reference Include="System.Drawing" />
@@ -119,6 +120,7 @@
     <Compile Include="Configuration\Interface\IAppConfig.cs" />
     <Compile Include="Configuration\Interface\IThumbnailConfiguration.cs" />
     <Compile Include="Configuration\Interface\ZoomAnchor.cs" />
+    <Compile Include="Hotkeys\GlobalHotKey.cs" />
     <Compile Include="Mediator\Handlers\Configuration\SaveConfigurationHandler.cs" />
     <Compile Include="Mediator\Handlers\Thumbnails\ThumbnailFrameSettingsUpdatedHandler.cs" />
     <Compile Include="Mediator\Handlers\Thumbnails\ThumbnailConfiguredSizeUpdatedHandler.cs" />

--- a/Eve-O-Preview/Hotkeys/GlobalHotKey.cs
+++ b/Eve-O-Preview/Hotkeys/GlobalHotKey.cs
@@ -26,10 +26,10 @@ namespace EveOPreview.UI.Hotkeys
 
         public static bool RegisterHotKey(ModifierKeys aModifier, Key aKey, Action aAction)
         {
-            if (aModifier == ModifierKeys.None)
+/*            if (aModifier == ModifierKeys.None)
             {
                 throw new ArgumentException("Modifier must not be ModifierKeys.None");
-            }
+            } */
             if (aAction is null)
             {
                 throw new ArgumentNullException(nameof(aAction));

--- a/Eve-O-Preview/Hotkeys/GlobalHotKey.cs
+++ b/Eve-O-Preview/Hotkeys/GlobalHotKey.cs
@@ -1,0 +1,162 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Runtime.InteropServices;
+using System.Windows.Input;
+
+/// <summary>
+/// Credits to Lumo from stackoverflow for this class.
+/// https://stackoverflow.com/posts/65412682/revisions
+/// </summary>
+namespace EveOPreview.UI.Hotkeys
+{
+   public class GlobalHotKey : IDisposable
+    {
+        /// <summary>
+        /// Registers a global hotkey
+        /// </summary>
+        /// <param name="aKeyGesture">e.g. Alt + Shift + Control + Win + S</param>
+        /// <param name="aAction">Action to be called when hotkey is pressed</param>
+        /// <returns>true, if registration succeeded, otherwise false</returns>
+        public static bool RegisterHotKey(string aKeyGestureString, Action aAction)
+        {
+            var c = new KeyGestureConverter();
+            KeyGesture aKeyGesture = (KeyGesture)c.ConvertFrom(aKeyGestureString);
+            return RegisterHotKey(aKeyGesture.Modifiers, aKeyGesture.Key, aAction);
+        }
+
+        public static bool RegisterHotKey(ModifierKeys aModifier, Key aKey, Action aAction)
+        {
+            if (aModifier == ModifierKeys.None)
+            {
+                throw new ArgumentException("Modifier must not be ModifierKeys.None");
+            }
+            if (aAction is null)
+            {
+                throw new ArgumentNullException(nameof(aAction));
+            }
+
+            System.Windows.Forms.Keys aVirtualKeyCode = (System.Windows.Forms.Keys)KeyInterop.VirtualKeyFromKey(aKey);
+            currentID = currentID + 1;
+            bool aRegistered = RegisterHotKey(window.Handle, currentID,
+                                        (uint)aModifier | MOD_NOREPEAT,
+                                        (uint)aVirtualKeyCode);
+
+            if (aRegistered)
+            {
+                registeredHotKeys.Add(new HotKeyWithAction(aModifier, aKey, aAction));
+            }
+            return aRegistered;
+        }
+
+        public void Dispose()
+        {
+            // unregister all the registered hot keys.
+            for (int i = currentID; i > 0; i--)
+            {
+                UnregisterHotKey(window.Handle, i);
+            }
+
+            // dispose the inner native window.
+            window.Dispose();
+        }
+
+        static GlobalHotKey()
+        {
+            window.KeyPressed += (s, e) =>
+            {
+                registeredHotKeys.ForEach(x =>
+                {
+                    if (e.Modifier == x.Modifier && e.Key == x.Key)
+                    {
+                        x.Action();
+                    }
+                });
+            };
+        }
+
+        private static readonly InvisibleWindowForMessages window = new InvisibleWindowForMessages();
+        private static int currentID;
+        private static uint MOD_NOREPEAT = 0x4000;
+        private static List<HotKeyWithAction> registeredHotKeys = new List<HotKeyWithAction>();
+
+        private class HotKeyWithAction
+        {
+
+            public HotKeyWithAction(ModifierKeys modifier, Key key, Action action)
+            {
+                Modifier = modifier;
+                Key = key;
+                Action = action;
+            }
+
+            public ModifierKeys Modifier { get; }
+            public Key Key { get; }
+            public Action Action { get; }
+        }
+
+        // Registers a hot key with Windows.
+        [DllImport("user32.dll")]
+        private static extern bool RegisterHotKey(IntPtr hWnd, int id, uint fsModifiers, uint vk);
+        // Unregisters the hot key with Windows.
+        [DllImport("user32.dll")]
+        private static extern bool UnregisterHotKey(IntPtr hWnd, int id);
+
+        private class InvisibleWindowForMessages : System.Windows.Forms.NativeWindow, IDisposable
+        {
+            public InvisibleWindowForMessages()
+            {
+                CreateHandle(new System.Windows.Forms.CreateParams());
+            }
+
+            private static int WM_HOTKEY = 0x0312;
+            protected override void WndProc(ref System.Windows.Forms.Message m)
+            {
+                base.WndProc(ref m);
+
+                if (m.Msg == WM_HOTKEY)
+                {
+                    var aWPFKey = KeyInterop.KeyFromVirtualKey(((int)m.LParam >> 16) & 0xFFFF);
+                    ModifierKeys modifier = (ModifierKeys)((int)m.LParam & 0xFFFF);
+                    if (KeyPressed != null)
+                    {
+                        KeyPressed(this, new HotKeyPressedEventArgs(modifier, aWPFKey));
+                    }
+                }
+            }
+
+            public class HotKeyPressedEventArgs : EventArgs
+            {
+                private ModifierKeys _modifier;
+                private Key _key;
+
+                internal HotKeyPressedEventArgs(ModifierKeys modifier, Key key)
+                {
+                    _modifier = modifier;
+                    _key = key;
+                }
+
+                public ModifierKeys Modifier
+                {
+                    get { return _modifier; }
+                }
+
+                public Key Key
+                {
+                    get { return _key; }
+                }
+            }
+
+
+            public event EventHandler<HotKeyPressedEventArgs> KeyPressed;
+
+            #region IDisposable Members
+
+            public void Dispose()
+            {
+                this.DestroyHandle();
+            }
+
+            #endregion
+        }
+    }
+}

--- a/Eve-O-Preview/Services/Implementation/ThumbnailManager.cs
+++ b/Eve-O-Preview/Services/Implementation/ThumbnailManager.cs
@@ -85,7 +85,7 @@ namespace EveOPreview.Services
 			{
 				if (activeWindowTagged)
 				{
-					// activate another window //
+					// activate next window //
 					ThumbnailActivated(kvp.Key);
 					windowActivated = true;
 					break;
@@ -95,6 +95,7 @@ namespace EveOPreview.Services
 					activeWindowTagged = true;
 				}
 			}
+			// window was not activated, meaning it was last in the list, cycle restart from 1st.
 			if (!windowActivated)
 			{
 				var k = this._thumbnailViews.Keys.GetEnumerator();

--- a/Eve-O-Preview/Services/Implementation/ThumbnailManager.cs
+++ b/Eve-O-Preview/Services/Implementation/ThumbnailManager.cs
@@ -92,6 +92,10 @@ namespace EveOPreview.Services
             {
 				activeWindowIndex = 0;
 			}
+			if (this._configuration.MinimizeInactiveClients && !this._configuration.IsPriorityClient(this._activeClient.Title))
+			{
+				this._windowManager.MinimizeWindow(this._activeClient.Handle, false);
+			}
 			this.ThumbnailActivated(this._sortedCyclableThumbnailViews[activeWindowIndex]);
 		}
 
@@ -106,6 +110,10 @@ namespace EveOPreview.Services
 			if (activeWindowIndex >= this._sortedThumbnailViews.Count)
 			{
 				activeWindowIndex = 0;
+			}
+			if (this._configuration.MinimizeInactiveClients && !this._configuration.IsPriorityClient(this._activeClient.Title))
+			{
+				this._windowManager.MinimizeWindow(this._activeClient.Handle, false);
 			}
 			this.ThumbnailActivated(this._sortedThumbnailViews[activeWindowIndex]);
 		}

--- a/Eve-O-Preview/Services/Implementation/ThumbnailManager.cs
+++ b/Eve-O-Preview/Services/Implementation/ThumbnailManager.cs
@@ -72,7 +72,7 @@ namespace EveOPreview.Services
 		public void Start()
 		{
 			this._thumbnailUpdateTimer.Start();
-			GlobalHotKey.RegisterHotKey("Ctrl + Tab", () => HotkeyPressed_Handler());
+			GlobalHotKey.RegisterHotKey("Ctrl + Tab", HotkeyPressed_Handler);
 			this.RefreshThumbnails();
 		}
 

--- a/Eve-O-Preview/Services/Implementation/ThumbnailManager.cs
+++ b/Eve-O-Preview/Services/Implementation/ThumbnailManager.cs
@@ -1,6 +1,4 @@
 ﻿using System;
-using System.Windows.Forms;
-using System.ComponentModel;
 using System.Collections.Generic;
 using System.Drawing;
 using System.Threading.Tasks;
@@ -98,11 +96,11 @@ namespace EveOPreview.Services
 				}
 			}
 			if (!windowActivated)
-            {
+			{
 				var k = this._thumbnailViews.Keys.GetEnumerator();
 				k.MoveNext();
 				ThumbnailActivated(k.Current);
-            }
+			}
 		}
 
 		public void Stop()

--- a/Eve-O-Preview/Services/Implementation/ThumbnailManager.cs
+++ b/Eve-O-Preview/Services/Implementation/ThumbnailManager.cs
@@ -72,7 +72,7 @@ namespace EveOPreview.Services
 		public void Start()
 		{
 			this._thumbnailUpdateTimer.Start();
-			GlobalHotKey.RegisterHotKey("Ctrl + Tab", HotkeyPressed_Handler);
+			GlobalHotKey.RegisterHotKey(_configuration.NextWindowShortcut, HotkeyPressed_Handler);
 			this.RefreshThumbnails();
 		}
 

--- a/Eve-O-Preview/Services/Implementation/ThumbnailManager.cs
+++ b/Eve-O-Preview/Services/Implementation/ThumbnailManager.cs
@@ -74,6 +74,7 @@ namespace EveOPreview.Services
 		{
 			this._thumbnailUpdateTimer.Start();
 			GlobalHotKey.RegisterHotKey(_configuration.NextWindowShortcut, NextWindowHandler);
+			GlobalHotKey.RegisterHotKey(_configuration.NextAnyWindowShortcut, NextAnyWindowHandler);
 			this.RefreshThumbnails();
 		}
 
@@ -88,6 +89,22 @@ namespace EveOPreview.Services
 			activeWindowIndex++;
 			if (activeWindowIndex >= this._cyclableThumbnailViews.Count)
             {
+				activeWindowIndex = 0;
+			}
+			this.ThumbnailActivated(windows[activeWindowIndex]);
+		}
+
+		private void NextAnyWindowHandler()
+		{
+			var windows = new List<IntPtr>(this._thumbnailViews.Keys);
+			var activeWindowIndex = windows.IndexOf(this._activeClient.Handle);
+			if (activeWindowIndex == -1)
+			{
+				activeWindowIndex = 0;
+			}
+			activeWindowIndex++;
+			if (activeWindowIndex >= this._thumbnailViews.Count)
+			{
 				activeWindowIndex = 0;
 			}
 			this.ThumbnailActivated(windows[activeWindowIndex]);

--- a/Eve-O-Preview/Services/Implementation/ThumbnailManager.cs
+++ b/Eve-O-Preview/Services/Implementation/ThumbnailManager.cs
@@ -23,7 +23,6 @@ namespace EveOPreview.Services
 		private const int DEFAULT_LOCATION_CHANGE_NOTIFICATION_DELAY = 2;
 
 		private const string DEFAULT_CLIENT_TITLE = "EVE";
-		private HotkeyHandler _hotkeyHandler;
 		#endregion
 
 		#region Private fields


### PR DESCRIPTION
Shortcurt that activates next EVE window.
If EVE window was not active upon keypress - activates next active after last one was active.

configuration options:
**NextWindowShortcut**: String
Text representation of shortcut to be used for activating next window. E.g. **"NextWindowShortcut": "Oemtilde"** (default Ctrl+Tab)
See https://docs.microsoft.com/en-us/dotnet/api/system.windows.forms.keys?view=net-5.0
**NextAnyWindowShortcut**: String. Same as above, but cycle through all EVE windows ignoring the following option (default Ctrl+Shift+Tab).
**NextWindowIgnoredTitles** : Array of Strings.
Array of Thumbnail titles to be ignored within next app function.
E.g.
**"NextWindowIgnoredTitles": [
    "EVE",
    "EVE - Not A Spy"
],**
will exclude not logged in EVE client and character "Not A Spy" from next app function.
**NextWindowOrdering**: Array of Strings.
Fixed ordering for cyclable windows. Will always push these titles in the beginning of thumbnails to cycle through, rest will be inserted as preview noticed them (e.g. on reconnection sorting will be broken, but with this fixed ordering you can define sorted list)