### PR TITLE
Fix for preview flicker bug

### DIFF
--- a/Eve-O-Preview/Services/Implementation/ThumbnailManager.cs
+++ b/Eve-O-Preview/Services/Implementation/ThumbnailManager.cs
@@ -183,7 +183,7 @@ namespace EveOPreview.Services
 			string foregroundWindowTitle = null;
 
 			// Check if the foreground window handle is one of the known handles for client windows or their thumbnails
-			bool isClientWindow = this.IsClientWindowActive(foregroundWindowHandle);
+			bool isClientWindow = this.IsClientWindowActive(foregroundWindowHandle) || foregroundWindowHandle == IntPtr.Zero;
 
 			if (foregroundWindowHandle == this._activeClient.Handle)
 			{


### PR DESCRIPTION
this should fix issue #185 by treating a null foreground window handle as an eve client, and only hiding previews when the foreground client is non-null *and* non-EVE.